### PR TITLE
Add Debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ Default: undef
 This module will NOT make any changes to your postfix installation, so you
 will need to adjust your configuration using the postfix module.
 
-Written and tested for CentOS 7 only. To get the package, please see
+Written and tested for CentOS 7 and Debian stretch (9) only. To get the package for CentOS, please see
 https://copr.fedorainfracloud.org/coprs/natolumin/postsrsd/

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class postsrsd::params {
     'Debian': {
       $package_name   = 'postsrsd'
       $service_name   = 'postsrsd'
-      $sysconfig_file = '/etc/sysconfig/postsrsd'
+      $sysconfig_file = '/etc/default/postsrsd'
     }
     'RedHat', 'Amazon': {
       $package_name   = 'postsrsd'

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
add Debian (stretch) support. The main thing is, that Debian does not have a /etc/sysconfig directory but uses /etc/default for the same purpose.
Second commit reflects the fact, that I use and tested the module on Debian stable.
I also deleted Debian 6 (cannot remember how it was called) from metadata.